### PR TITLE
Add single comparison chart

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,52 @@
+import fs from "fs";
+import { ApproximationResult } from "./models";
+
+export function createComparisonGraph(
+  x: number[],
+  y: number[],
+  results: ApproximationResult[],
+  filename: string,
+) {
+  const minX = Math.min(...x);
+  const maxX = Math.max(...x);
+  const steps = 100;
+  const xCurve = Array.from({ length: steps }, (_, i) =>
+    minX + ((maxX - minX) * i) / (steps - 1),
+  );
+
+  const traces = results.map((r) => ({
+    x: xCurve,
+    y: xCurve.map((xi) => r.predict(xi)),
+    mode: "lines",
+    type: "scatter",
+    name: r.name,
+  }));
+
+  const tracePoints = {
+    x,
+    y,
+    mode: "markers",
+    type: "scatter",
+    name: "Исходные данные",
+  };
+
+  const data = [tracePoints, ...traces];
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+<div id="plot" style="width:800px;height:600px;"></div>
+<script>
+  const data = ${JSON.stringify(data)};
+  const layout = { title: 'Сравнение методов', xaxis: { title: 'x' }, yaxis: { title: 'y' } };
+  Plotly.newPlot('plot', data, layout);
+</script>
+</body>
+</html>`;
+
+  fs.writeFileSync(filename, html, "utf-8");
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { quadratic } from "./math/quadratic";
 import { cubic } from "./math/qubic";
 import { power } from "./math/power";
 import { readPointsFromFile } from "./io/readInput";
+import { createComparisonGraph } from "./graph";
 function describeCorrelation(r: number): string {
   if (Math.abs(r) >= 0.9) return "весьма высокая связь";
   if (Math.abs(r) >= 0.7) return "высокая связь";
@@ -71,6 +72,9 @@ function main() {
       console.log(`R² = ${r.r2.toFixed(4)} — ${describeDetermination(r.r2)}`);
     }
   });
+
+  createComparisonGraph(x, y, results, "comparison.html");
+  console.log("График сохранен в comparison.html");
 
   const best = results.reduce((min, curr) =>
     curr.sigma < min.sigma ? curr : min,


### PR DESCRIPTION
## Summary
- replace per-method graphing with a single Plotly comparison graph
- output graph after listing approximation details

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68416f4babf88329bbefc0c70176a73c